### PR TITLE
Add transit layer

### DIFF
--- a/scene.yaml
+++ b/scene.yaml
@@ -201,6 +201,35 @@ layers:
                         fill: white
                         # stroke: { color: black, width: 4 }
 
+    transit:
+        data: { source: osm }
+        properties:
+            key_text: ""
+            value_text: ""
+        draw:
+            lines:
+                interactive: true
+                order: 2
+                color: '#bbb'
+                width: 2px
+        red:
+            filter: |
+                function () {
+                    return feature[properties.key_text] && feature[properties.key_text].toLowerCase().indexOf(properties.value_text.toLowerCase()) > -1;
+                }
+            draw:
+                lines:
+                    order: 100
+                    color: red
+                    width: 2px
+                text:
+                    order: 100
+                    text_source: name
+                    font:
+                        typeface: 8pt Lucida Grande
+                        fill: white
+                        # stroke: { color: black, width: 4 }
+
     buildings:
         data: { source: osm }
         properties: 


### PR DESCRIPTION
Adds the new transit layer to the explorer. (Can really reduce style rule duplication by adding the ability to map multiple data source layers to one scene layer.)

<img width="1276" alt="screen shot 2015-07-21 at 3 22 31 pm" src="https://cloud.githubusercontent.com/assets/16733/8810336/5f41d5c0-2fbc-11e5-9a23-3006d1b009e8.png">
